### PR TITLE
updated to ack requests and to check errors on WaitFor.  Flush is als…

### DIFF
--- a/nbd/aiofile.go
+++ b/nbd/aiofile.go
@@ -8,7 +8,6 @@
 package nbd
 
 import (
-	"errors"
 	"github.com/traetox/goaio"
 	"golang.org/x/net/context"
 	"os"
@@ -29,7 +28,12 @@ func (afb *AioFileBackend) WriteAt(ctx context.Context, b []byte, offset int64, 
 	if err != nil {
 		return 0, err
 	}
-	afb.aio.WaitFor(requestId)
+	if err := afb.aio.WaitFor(requestId); err != nil {
+		return 0, err
+	}
+	if err := afb.aio.Ack(requestId); err != nil {
+		return 0, err
+	}
 	return len(b), err
 }
 
@@ -42,7 +46,12 @@ func (afb *AioFileBackend) ReadAt(ctx context.Context, b []byte, offset int64) (
 	if err != nil {
 		return 0, err
 	}
-	afb.aio.WaitFor(requestId)
+	if err := afb.aio.WaitFor(requestId); err != nil {
+		return 0, err
+	}
+	if err := afb.aio.Ack(requestId); err != nil {
+		return 0, err
+	}
 	return len(b), err
 }
 
@@ -53,7 +62,7 @@ func (afb *AioFileBackend) TrimAt(ctx context.Context, length int, offset int64)
 
 // Flush implements Backend.Flush
 func (afb *AioFileBackend) Flush(ctx context.Context) error {
-	return errors.New("Flush not supported")
+	return afb.aio.Flush()
 }
 
 // Close implements Backend.Close


### PR DESCRIPTION
…o issued

I updated to check the errors on WaitFor and to Ack request on completion.  Without Acking the map that tracks the ACKs will grow indefinitely.

Testing shows a significantly lower blocking rate.  I am showing throughput closer to 280Mbit/s on my i5-4690k and a cheapo SSD.  No errors on testing.
