### PR TITLE
removed the need for Ack.  WaitFor returns an error if one ocurred

### DIFF
--- a/nbd/aiofile.go
+++ b/nbd/aiofile.go
@@ -31,9 +31,6 @@ func (afb *AioFileBackend) WriteAt(ctx context.Context, b []byte, offset int64, 
 	if err := afb.aio.WaitFor(requestId); err != nil {
 		return 0, err
 	}
-	if err := afb.aio.Ack(requestId); err != nil {
-		return 0, err
-	}
 	if fua {
 		if err := afb.aio.Flush(); err != nil {
 			return 0, err
@@ -52,9 +49,6 @@ func (afb *AioFileBackend) ReadAt(ctx context.Context, b []byte, offset int64) (
 		return 0, err
 	}
 	if err := afb.aio.WaitFor(requestId); err != nil {
-		return 0, err
-	}
-	if err := afb.aio.Ack(requestId); err != nil {
 		return 0, err
 	}
 	return len(b), err


### PR DESCRIPTION
The WaitFor call now returns an error if there was one.  If a request flat out fails, its up to the caller to deal with it.  Requests can fail if you provide a bad ID, or if the kernel returns an error code or just flat fails to write anything.
