### PR TITLE
Reverse ceph build directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: go
 
-gobuild_args: -tags noceph
-
 go:
   - 1.5
   - 1.6
   - tip
 
 script:
- - go test -tags noceph -v ./...
+ - go test -v ./...
 
 install:
- - go get -t -tags noceph ./...
+ - go get -t ./...

--- a/nbd/rbd.go
+++ b/nbd/rbd.go
@@ -1,10 +1,14 @@
-// +build linux,!noceph
+// +build ceph
 
-// The above build tag specifies this file is only to be built on linux (because
-// building librados is difficult elsewhere). If you want it to build elsewhere,
-// add your OS as appropriately. If you are having difficulty building on linux
-// or want to build without librados present, then use
-//    go build -tags 'noceph'
+// The above build tag specifies this file is only to be built
+// when the `ceph` tag is explicitly specified, as follows:
+//    go build -tags 'ceph'
+//
+// NOTE: at the time of writing it is difficult to build librados
+// on platforms other than Linux. In case you want to build this file,
+// (and thus use go-ceph) it is recommended to do this on Linux.
+// Other platforms may work (with some work) but is not guaranteed.
+// You have been warned.
 
 package nbd
 


### PR DESCRIPTION
Because of this one has to explicitly specify the  tag
in order to build the go-ceph dependend code.

fixes #6

Signed-off-by: Glen De Cauwsemaecker <contact@glendc.com>